### PR TITLE
Allow selecting multiple templates at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ tasks:
   - base16_builder: {}
     register: base16_schemes
 
+  # Build every color scheme for a few select templates
+  - base16_builder:
+      template:
+        - shell
+        - i3
+        - qutebrowser
+    register: base16_schemes
+
   # Download latest color scheme and template source files, but don't build anything
   - base16_builder:
       update: yes
@@ -143,10 +151,10 @@ scheme_family:
   default: Build all schemes
 template:
   description:
-    - Set this to the name of a template to only build that one template instead of building all, which is the default
-    - Only building a single template is much faster then building all
+    - Set this to names of templates to only build those templates instead of building all, which is the default
+    - Only building a few templates is much faster then building all
   required: false
-  type: string
+  type: list
   default: Build all templates
 cache_dir:
   description:

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ scheme_family:
   default: Build all schemes
 template:
   description:
-    - Set this to names of templates to only build those templates instead of building all, which is the default
+    - Set this to the name of a template or a list of template names to only build them instead of building all, which is the default
     - Only building a few templates is much faster then building all
   required: false
   type: list

--- a/library/base16_builder.py
+++ b/library/base16_builder.py
@@ -37,7 +37,7 @@ options:
     default: Build all schemes
   template:
     description:
-      - Set this to names of templates to only build those templates instead of building all, which is the default
+      - Set this to the name of a template or a list of template names to only build them instead of building all, which is the default
       - Only building a few templates is much faster then building all
     required: false
     type: list

--- a/library/base16_builder.py
+++ b/library/base16_builder.py
@@ -37,10 +37,10 @@ options:
     default: Build all schemes
   template:
     description:
-      - Set this to the name of a template to only build that one template instead of building all, which is the default
-      - Only building a single template is much faster then building all
+      - Set this to names of templates to only build those templates instead of building all, which is the default
+      - Only building a few templates is much faster then building all
     required: false
-    type: string
+    type: list
     default: Build all templates
   cache_dir:
     description:
@@ -143,6 +143,14 @@ EXAMPLES = """
 # Build every color scheme for a single template
 - base16_builder:
     template: shell
+  register: base16_schemes
+
+# Build every color scheme for a few select templates
+- base16_builder:
+    template:
+      - shell
+      - i3
+      - qutebrowser
   register: base16_schemes
 
 # Build every color scheme for every template
@@ -560,7 +568,7 @@ class TemplateRepo(object):
         if module_template_arg is None:
             return True
 
-        return self.name == module_template_arg
+        return self.name in module_template_arg
 
 
 class Base16Builder(object):
@@ -612,7 +620,7 @@ class Base16Builder(object):
             if len(scheme_result) == 1 and self.module.params["template"]:
                 failure_msg = "Failed to build any templates."
                 if self.module.params["template"]:
-                    failure_msg = '{} Template name "{}" was passed, but didn\'t match any known templates'.format(
+                    failure_msg = '{} Template names {} were passed, but didn\'t match any known templates'.format(
                         failure_msg, self.module.params["template"]
                     )
 
@@ -644,7 +652,7 @@ def main():
             build=dict(type="bool", required=False, default=True),
             scheme=dict(type="str", required=False),
             scheme_family=dict(type="str", required=False),
-            template=dict(type="str", required=False),
+            template=dict(type="list", required=False),
             cache_dir=dict(type="str", required=False, default=default_cache_dir),
             schemes_source=dict(
                 type="str",

--- a/test/test_base16_builder.py
+++ b/test/test_base16_builder.py
@@ -646,5 +646,5 @@ class TestBase16Builder(unittest.TestCase):
 
         self.assertEqual(
             result.exception.args[0]["msg"],
-            'Failed to build any templates. Template name "not-a-real-template" was passed, but didn\'t match any known templates',
+            'Failed to build any templates. Template names [\'not-a-real-template\'] were passed, but didn\'t match any known templates',
         )


### PR DESCRIPTION
Currently, we can make build one or all templates.
Users may want to use a few templates. Keeping those in a single
variable is ideal, since you don't need Ansible loops nor multiple
tasks. However, building all the templates takes time (mostly for the
first download), internet data and disk space (about 158 MiB now).

This commit allows selecting more than one templates, reducing those
drawbacks to a minimum. It essentially changes the type of the
`template` argument, making it a `list` instead of a `str`. Since
Ansible converts strings to one-item list, this change does not break
compatibility.

However, it will still download some uneeded files, thanks to the
rendered templates being embeded in their git repositories themselves.

The same could be implemented for schemes, although the existence of
`scheme_family` makes it harder and slightly redundant to do so.